### PR TITLE
d_taitof3: save EEPROM data in savestates

### DIFF
--- a/src/burn/drv/taito/d_taitof3.cpp
+++ b/src/burn/drv/taito/d_taitof3.cpp
@@ -1664,6 +1664,8 @@ static INT32 DrvScan(INT32 nAction, INT32 *pnMin)
 		SCAN_VAR(sound_cpu_in_reset);
 		if (f3_game == ARKRETRN) BurnTrackballScan();
 
+		EEPROMScan(nAction, pnMin);
+
 		if (nAction & ACB_WRITE) {
 			for (INT32 i = 0; i < 0x2000; i+=4) {
 				DrvVRAMExpand(i);


### PR DESCRIPTION
Upstream added this in 7c9e826 last year while fixing issues with runahead, and I believe the sporadic desyncs in F3 games on Fightcade are due to the same issue.