### PR TITLE
d_taitof3: Ensure EEPROM data is actually saved in savestates

### DIFF
--- a/src/burn/devices/eeprom.cpp
+++ b/src/burn/devices/eeprom.cpp
@@ -385,3 +385,20 @@ void EEPROMScan(INT32 nAction, INT32* pnMin)
 //		BurnAcb(&ba);
 //	}
 }
+
+void EEPROMScanData(INT32 nAction, INT32* pnMin)
+{
+#if defined FBNEO_DEBUG
+	if (!DebugDev_EEPROMInitted) bprintf(PRINT_ERROR, _T("EEPROMScanData called without init\n"));
+#endif
+
+	struct BurnArea ba;
+
+	if (nAction & ACB_NVRAM) {
+		memset(&ba, 0, sizeof(ba));
+		ba.Data		= eeprom_data;
+		ba.nLen		= MEMORY_SIZE;
+		ba.szName	= "EEPROM Data";
+		BurnAcb(&ba);
+	}
+}

--- a/src/burn/devices/eeprom.h
+++ b/src/burn/devices/eeprom.h
@@ -54,6 +54,7 @@ void EEPROMSetClockLine(INT32 state);
 void EEPROMFill(const UINT8 *data, INT32 offset, INT32 length);
 
 void EEPROMScan(INT32 nAction, INT32* pnMin);
+void EEPROMScanData(INT32 nAction, INT32* pnMin);
 
 // Some buggy games throw a lot of garbage at the EEPROM (Taito F3)
 void EEPROMIgnoreErrMessage(INT32 onoff);

--- a/src/burn/drv/taito/d_taitof3.cpp
+++ b/src/burn/drv/taito/d_taitof3.cpp
@@ -1665,6 +1665,7 @@ static INT32 DrvScan(INT32 nAction, INT32 *pnMin)
 		if (f3_game == ARKRETRN) BurnTrackballScan();
 
 		EEPROMScan(nAction, pnMin);
+		EEPROMScanData(nAction, pnMin);
 
 		if (nAction & ACB_WRITE) {
 			for (INT32 i = 0; i < 0x2000; i+=4) {


### PR DESCRIPTION
Because the function that should be doing that ... wasn't. The behavior is commented out (line 375 onward), and has been since FBNeo's first commit, for reasons beyond my understanding.

Now, I don't feel comfortable uncommenting this section of code, as this would affect every single driver with an EEPROM chip and there's far too much risk involved with breaking other drivers by doing so. So instead a new function was added to specifically copy data from the EEPROM, and the Taito F3 driver now calls that function as well.