### PR TITLE
Updates: NeoGeo, Megadrive, SMS

### DIFF
--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -43576,10 +43576,10 @@ STD_ROM_PICK(md_fightveng)
 STD_ROM_FN(md_fightveng)
 
 struct BurnDriver BurnDrvmd_fightveng = {
-	"md_fightveng", NULL, NULL, NULL, "2021",
+	"md_fightveng", "md_fightvengt", NULL, NULL, "2021",
 	"Fight for Vengeance (HB)\0", NULL, "PSCD Games", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
 	MegadriveGetZipName, md_fightvengRomInfo, md_fightvengRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
 	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
@@ -43587,17 +43587,17 @@ struct BurnDriver BurnDrvmd_fightveng = {
 
 // Fight for Vengeance - Tournament Edition (HB)
 static struct BurnRomInfo md_fightvengtRomDesc[] = {
-	{ "Fight for Vengeance - Tournament Edition v3.0 (2022)(GFE).bin", 4194304, 0x813a61a6, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+	{ "Fight for Vengeance - Tournament Edition (2022)(Genesis Fight Engine).bin", 4194304, 0x813a61a6, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
 };
 
 STD_ROM_PICK(md_fightvengt)
 STD_ROM_FN(md_fightvengt)
 
 struct BurnDriver BurnDrvmd_fightvengt = {
-	"md_fightvengt", "md_fightveng", NULL, NULL, "2022",
-	"Fight for Vengeance - Tournament Edition (HB, v3.0)\0", NULL, "Genesis Fight Engine", "Sega Megadrive",
+	"md_fightvengt", NULL, NULL, NULL, "2022",
+	"Fight for Vengeance - Tournament Edition (HB)\0", NULL, "Genesis Fight Engine", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_CLONE | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
+	BDF_GAME_WORKING | BDF_16BIT_ONLY | BDF_HOMEBREW, 2, HARDWARE_SEGA_MEGADRIVE, GBF_VSFIGHT, 0,
 	MegadriveGetZipName, md_fightvengtRomInfo, md_fightvengtRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
 	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -43801,6 +43801,25 @@ struct BurnDriver BurnDrvmd_sor2tnwoa = {
 	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
 };
 
+// Streets of Rage - Killer Difficulty by gsaurus
+// https://www.romhacking.net/hacks/1341/
+static struct BurnRomInfo md_sorkillerRomDesc[] = {
+	{ "Streets of Rage - Killer Difficulty (2012)(gsaurus).bin", 0x080000, 0x86eed3d6, BRF_PRG | SEGA_MD_ROM_LOAD16_WORD_SWAP | SEGA_MD_ROM_OFFS_000000  },
+};
+
+STD_ROM_PICK(md_sorkiller)
+STD_ROM_FN(md_sorkiller)
+
+struct BurnDriver BurnDrvmd_sorkiller = {
+	"md_sorkiller", "md_sor", NULL, NULL, "2012",
+	"Streets of Rage (Killer Difficulty v0.9h, hack)\0", NULL, "gsaurus", "Sega Megadrive",
+	NULL, NULL, NULL, NULL,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_16BIT_ONLY, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
+	MegadriveGetZipName, md_sorkillerRomInfo, md_sorkillerRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,
+	MegadriveInit, MegadriveExit, MegadriveFrame, MegadriveDraw, MegadriveScan,
+	&bMegadriveRecalcPalette, 0x100, 320, 224, 4, 3
+};
+
 // Insane Pain (HB)
 
 static struct BurnRomInfo md_insanepainRomDesc[] = {

--- a/src/burn/drv/megadrive/d_megadrive.cpp
+++ b/src/burn/drv/megadrive/d_megadrive.cpp
@@ -43812,7 +43812,7 @@ STD_ROM_FN(md_sorkiller)
 
 struct BurnDriver BurnDrvmd_sorkiller = {
 	"md_sorkiller", "md_sor", NULL, NULL, "2012",
-	"Streets of Rage (Killer Difficulty v0.9h, hack)\0", NULL, "gsaurus", "Sega Megadrive",
+	"Streets of Rage (Killer Difficulty v0.9, hack)\0", NULL, "gsaurus", "Sega Megadrive",
 	NULL, NULL, NULL, NULL,
 	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_16BIT_ONLY, 2, HARDWARE_SEGA_MEGADRIVE, GBF_SCRFIGHT, 0,
 	MegadriveGetZipName, md_sorkillerRomInfo, md_sorkillerRomName, NULL, NULL, NULL, NULL, MegadriveInputInfo, MegadriveDIPInfo,

--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -18937,34 +18937,36 @@ struct BurnDriver BurnDrvmslug4lw = {
 // Metal Slug 4 (20th Anniversary GOTVG Hack)
 
 static struct BurnRomInfo mslug4aRomDesc[] = {
-	{ "263-p1a.bin",   0x100000, 0x1b5121b6, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
-	{ "263-p2a.bin",   0x400000, 0xf132898f, 1 | BRF_ESS | BRF_PRG }, //  1
+	{ "263-p1a.p1",    0x100000, 0x54dae71f, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "263-p2a.sp2",   0x400000, 0x87dc01b9, 1 | BRF_ESS | BRF_PRG }, //  1 
 
-	{ "263-s1d.s1",    0x080000, 0x1eaa05e0, 2 | BRF_GRA },           //  2 Text layer tiles
+	/* The Encrypted Boards do not have an s1 rom, data for it comes from the Cx ROMs */
+	/* Encrypted */
+	{ "263-c1.c1",     0x800000, 0x84865f8a, 3 | BRF_GRA },           //  2 Sprite data
+	{ "263-c2.c2",     0x800000, 0x81df97f2, 3 | BRF_GRA },           //  3 
+	{ "263-c3.c3",     0x800000, 0x1a343323, 3 | BRF_GRA },           //  4 
+	{ "263-c4.c4",     0x800000, 0x942cfb44, 3 | BRF_GRA },           //  5 
+	{ "263-c5.c5",     0x800000, 0xa748854f, 3 | BRF_GRA },           //  6 
+	{ "263-c6.c6",     0x800000, 0x5c8ba116, 3 | BRF_GRA },           //  7 
 
-	{ "263-c1d.c1",    0x800000, 0xa75ffcde, 3 | BRF_GRA },           //  3 Sprite data
-	{ "263-c2d.c2",    0x800000, 0x5ab0d12b, 3 | BRF_GRA },           //  4
-	{ "263-c3d.c3",    0x800000, 0x61af560c, 3 | BRF_GRA },           //  5
-	{ "263-c4d.c4",    0x800000, 0xf2c544fd, 3 | BRF_GRA },           //  6
-	{ "263-c5d.c5",    0x800000, 0x84c66c44, 3 | BRF_GRA },           //  7
-	{ "263-c6d.c6",    0x800000, 0x5ed018ab, 3 | BRF_GRA },           //  8
+	/* Encrypted */
+	{ "263-m1.m1",     0x020000, 0x46ac8228, 4 | BRF_ESS | BRF_PRG }, //  8 Z80 code
 
-	{ "263-m1d.m1",    0x020000, 0xef5db532, 4 | BRF_ESS | BRF_PRG }, //  9 Z80 code
-
-	{ "263-v1d.v1",    0x800000, 0xfd6b982e, 5 | BRF_SND },           // 10 Sound data
-	{ "263-v2d.v2",    0x800000, 0x20125227, 5 | BRF_SND },           // 11
+	/* Encrypted */
+	{ "263-v1.v1",     0x800000, 0x01e9b9cd, 5 | BRF_SND },           //  9 Sound data
+	{ "263-v2.v2",     0x800000, 0x4ab2bf81, 5 | BRF_SND },           // 10 
 };
 
 STDROMPICKEXT(mslug4a, mslug4a, neogeo)
 STD_ROM_FN(mslug4a)
 
 struct BurnDriver BurnDrvmslug4a = {
-	"mslug4a", "mslug4", "neogeo", NULL, "2021",
+	"mslug4a", "mslug4", "neogeo", NULL, "2022",
 	"Metal Slug 4 (20th Anniversary, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_PLATFORM, FBF_MSLUG,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_CMC50 | HARDWARE_SNK_ENCRYPTED_M1, GBF_RUNGUN, FBF_MSLUG,
 	NULL, mslug4aRomInfo, mslug4aRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
-	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	mslug4Init, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
 };
 
@@ -20882,23 +20884,26 @@ struct BurnDriver BurnDrvmslug4lwq = {
 };
 
 // Metal Slug 4 (The Longest Battle, Hack)
+
 static struct BurnRomInfo mslug4qRomDesc[] = {
-	{ "263-p1q.bin",    0x100000, 0x461579ae, 1 | BRF_ESS | BRF_PRG },  //  0 68K code
-	{ "263-p2q.bin",    0x400000, 0xa4d2e871, 1 | BRF_ESS | BRF_PRG },  //  1
-	
-	{ "263-s1d.s1",     0x080000, 0x1eaa05e0, 2 | BRF_GRA },            //  2 Text layer tiles
+	{ "263-p1q.p1",    0x100000, 0x1b5121b6, 1 | BRF_ESS | BRF_PRG }, //  0 68K code
+	{ "263-p2q.sp2",   0x400000, 0xf132898f, 1 | BRF_ESS | BRF_PRG }, //  1 
 
-	{ "263-c1d.c1",     0x800000, 0xa75ffcde, 3 | BRF_GRA },            //  3 Sprite data
-	{ "263-c2d.c2",     0x800000, 0x5ab0d12b, 3 | BRF_GRA },            //  4
-	{ "263-c3d.c3",     0x800000, 0x61af560c, 3 | BRF_GRA },            //  5
-	{ "263-c4d.c4",     0x800000, 0xf2c544fd, 3 | BRF_GRA },            //  6
-	{ "263-c5d.c5",     0x800000, 0x84c66c44, 3 | BRF_GRA },            //  7
-	{ "263-c6d.c6",     0x800000, 0x5ed018ab, 3 | BRF_GRA },            //  8
+	/* The Encrypted Boards do not have an s1 rom, data for it comes from the Cx ROMs */
+	/* Encrypted */
+	{ "263-c1.c1",     0x800000, 0x84865f8a, 3 | BRF_GRA },           //  2 Sprite data
+	{ "263-c2.c2",     0x800000, 0x81df97f2, 3 | BRF_GRA },           //  3 
+	{ "263-c3.c3",     0x800000, 0x1a343323, 3 | BRF_GRA },           //  4 
+	{ "263-c4.c4",     0x800000, 0x942cfb44, 3 | BRF_GRA },           //  5 
+	{ "263-c5.c5",     0x800000, 0xa748854f, 3 | BRF_GRA },           //  6 
+	{ "263-c6.c6",     0x800000, 0x5c8ba116, 3 | BRF_GRA },           //  7 
 
-	{ "263-m1d.m1",     0x020000, 0xef5db532, 4 | BRF_ESS | BRF_PRG },  //  9 Z80 code
+	/* Encrypted */
+	{ "263-m1.m1",     0x020000, 0x46ac8228, 4 | BRF_ESS | BRF_PRG }, //  8 Z80 code
 
-	{ "263-v1d.v1",     0x800000, 0xfd6b982e, 5 | BRF_SND },            // 10 Sound data
-	{ "263-v2d.v2",     0x800000, 0x20125227, 5 | BRF_SND },            // 11
+	/* Encrypted */
+	{ "263-v1.v1",     0x800000, 0x01e9b9cd, 5 | BRF_SND },           //  9 Sound data
+	{ "263-v2.v2",     0x800000, 0x4ab2bf81, 5 | BRF_SND },           // 10 
 };
 
 STDROMPICKEXT(mslug4q, mslug4q, neogeo)
@@ -20908,9 +20913,9 @@ struct BurnDriver BurnDrvmslug4q = {
 	"mslug4q", "mslug4", "neogeo", NULL, "2022",
 	"Metal Slug 4 (The Longest Battle, Hack)\0", NULL, "hack", "Neo Geo MVS",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO, GBF_RUNGUN, FBF_MSLUG,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK | BDF_HISCORE_SUPPORTED, 2, HARDWARE_PREFIX_CARTRIDGE | HARDWARE_SNK_NEOGEO | HARDWARE_SNK_CMC50 | HARDWARE_SNK_ENCRYPTED_M1, GBF_RUNGUN, FBF_MSLUG,
 	NULL, mslug4qRomInfo, mslug4qRomName, NULL, NULL, NULL, NULL, neogeoInputInfo, neogeoDIPInfo,
-	NeoInit, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
+	mslug4Init, NeoExit, NeoFrame, NeoRender, NeoScan, &NeoRecalcPalette,
 	0x1000,	304, 224, 4, 3
 };
 

--- a/src/burn/drv/sms/d_sms.cpp
+++ b/src/burn/drv/sms/d_sms.cpp
@@ -916,20 +916,20 @@ struct BurnDriver BurnDrvsms_alexkiddj = {
 };
 
 
-// Alex Kidd in Radaxian Rumble 1.02e
+// Alex Kidd in Radaxian Rumble (Hack, v1.5)
 
 static struct BurnRomInfo sms_alexkiddrrRomDesc[] = {
-	{ "akrr102e.sms",	0x80000, 0x368b64b0, BRF_PRG | BRF_ESS },
+	{ "Alex Kidd in Radaxian Rumble 1.5.sms",	0x80000, 0x02760e17, BRF_PRG | BRF_ESS },
 };
 
 STD_ROM_PICK(sms_alexkiddrr)
 STD_ROM_FN(sms_alexkiddrr)
 
 struct BurnDriver BurnDrvsms_alexkiddrr = {
-	"sms_akrr102e", "sms_alexkidd", NULL, NULL, "2015",
-	"Alex Kidd in Radaxian Rumble (ver. 1.02e)\0", NULL, "Sega", "Sega Master System",
+	"sms_alexkiddrr", "sms_alexkidd", NULL, NULL, "2015",
+	"Alex Kidd in Radaxian Rumble (Hack, v1.5)\0", NULL, "Alianger", "Sega Master System",
 	NULL, NULL, NULL, NULL,
-	BDF_GAME_WORKING | BDF_CLONE, 2, HARDWARE_SEGA_MASTER_SYSTEM, GBF_MISC, 0,
+	BDF_GAME_WORKING | BDF_CLONE | BDF_HACK, 1, HARDWARE_SEGA_MASTER_SYSTEM, GBF_PLATFORM, 0,
 	SMSGetZipName, sms_alexkiddrrRomInfo, sms_alexkiddrrRomName, NULL, NULL, NULL, NULL, SMSInputInfo, SMSDIPInfo,
 	SMSInit, SMSExit, SMSFrame, SMSDraw, SMSScan, &SMSPaletteRecalc, 0x1E00,
 	256, 192, 4, 3


### PR DESCRIPTION
-md_fightveng/t: fixed tags. now, tournament edition is the parent rom
-added: md_sorkiller
-sms_alexkiddrr: updated crcs (v1.5)
-NeoGeo - mslug4a/mslug4q: fixed layout / crcs [Alicemu request]