### PR TITLE
feat(lua): Fix registersave/load hooks. Add value to memwatch callbacks

### DIFF
--- a/src/burner/luaengine.cpp
+++ b/src/burner/luaengine.cpp
@@ -910,7 +910,9 @@ static void CallRegisteredLuaMemHook_LuaMatch(unsigned int address, int size, un
 						//RefreshScriptSpeedStatus();
 						lua_pushinteger(LUA, address);
 						lua_pushinteger(LUA, size);
-						int errorcode = lua_pcall(LUA, 2, 0, 0);
+						lua_pushinteger(LUA, value);
+
+						int errorcode = lua_pcall(LUA, 3, 0, 0);
 						luaRunning /*info.running*/ = wasRunning;
 						//RefreshScriptSpeedStatus();
 						if (errorcode)
@@ -1541,6 +1543,9 @@ void luasav_save(const char *filename) {
 			unlink(luaSaveFilename);
 		}
 	}
+	else {
+		CallRegisteredLuaSaveFunctions(filename, saveData);
+	}
 }
 
 void luasav_load(const char *filename) {
@@ -1567,6 +1572,9 @@ void luasav_load(const char *filename) {
 			fclose(luaSaveFile);
 		}
 		CallRegisteredLuaLoadFunctions(slotnum, saveData);
+	}
+	else {
+		CallRegisteredLuaLoadFunctions(filename, saveData);
 	}
 }
 


### PR DESCRIPTION
Right now the `emu.registersave` and `emu.registerload` hooks do not work at all from within lua. They will only fire if you use fbneos menu to save and load states, as opposed to e.g.  `savestate.load("my_savestate")` or `savestate.save("my_savestate")` do not trigger the hook. I've added a quick hack to get them to trigger.
```
savestate.registersave(function(slot,)
  print("Registered save", slot)
end)
	
savestate.registerload(function(slot)
     print("Registered save", slot)
end)
```
Should now work.

Second: 
The lua memhooks for "ramwatch" (e.g. memory.registerread() , memory.registerwrite() ) etc do not currently return the current value at the address. Added the value (which was already in scope). If you tried to something like this, you would get
```
	memory.registerwrite(0xFF8800, function(address, size)
           memory.readbyte(0xFF8800)
	end)
```
You would get the value from the previous frame.
This will get you the correct value at the time where the breakpoint fires.
```
	memory.registerwrite(0xFF8800, function(address, size, value)
           print(value)
	end)
```